### PR TITLE
Fixed the crash while using useNativeDriver as true

### DIFF
--- a/lib/Bars.tsx
+++ b/lib/Bars.tsx
@@ -1,7 +1,7 @@
 import { ViewProperties, Animated, Image, View, ViewStyle, ImageStyle, Insets, ImageURISource, ImageRequireSource } from 'react-native';
 import { CLScrollBehaviour, CLScrollEffect } from './Behaviours';
 import * as React from 'react';
-import { BOTTOM_SHADOW_IMAGE, TOP_SHADOW_IMAGE, SEPARATOR_HEIGHT, CLEAR_COLOR } from './resources/Constants';
+import { SEPARATOR_HEIGHT, CLEAR_COLOR } from './resources/Constants';
 import { styles } from './resources/Styles';
 
 export interface CLBarProps extends ViewProperties {

--- a/lib/Bars.tsx
+++ b/lib/Bars.tsx
@@ -85,9 +85,9 @@ export class CLAppBar extends React.Component<CLBarProps, CLBarState> implements
             );
         } else {
             return (
-                <Animated.View {...this.props} style={[this.props.style, { height: this.state.heightAnimatedValue }]}>
+                <View pointerEvents="box-none" {...this.props} style={this.props.style}>
                     {this.renderItems(this.props.scrollBehaviourOffset)}
-                </Animated.View>
+                </View>
             );
         }
     }
@@ -107,7 +107,6 @@ export class CLAppBar extends React.Component<CLBarProps, CLBarState> implements
     protected renderItems = (scrollBehaviourOffset: Animated.AnimatedInterpolation): React.ReactElement<any>[] => {
         const children: React.ReactElement<any>[] = [];
         let index: number = 0;
-        let topPosition: number = (this.props.safeAreaInsets && this.props.safeAreaInsets.top) || 0;
 
         let translateYOffset: Animated.AnimatedInterpolation = new Animated.Value(0);
 
@@ -159,13 +158,8 @@ export class CLAppBar extends React.Component<CLBarProps, CLBarState> implements
                 <Animated.View
                     key={index}
                     style={{
-                        position: 'absolute',
-                        top: topPosition,
-                        left: 0,
-                        right: 0,
                         transform: [{ translateY }],
                         opacity: alpha,
-                        height,
                         zIndex: -index,
                         overflow: 'hidden'
                     }}
@@ -175,8 +169,6 @@ export class CLAppBar extends React.Component<CLBarProps, CLBarState> implements
             );
 
             children.push(item);
-
-            topPosition += itemMaxHeight;
             index++;
         }
 

--- a/lib/Container.tsx
+++ b/lib/Container.tsx
@@ -20,9 +20,9 @@ export interface CLContainerProps extends ViewProperties {
     useNativeDriver?: boolean;
     offset?: number;
     safeAreaInsets?: Insets;
-    renderScrollComponent?: (props: ScrollViewProperties) => React.ReactElement<any>;
-    renderBottomBar?: (props: CLBarProps) => React.ReactElement<CLBarProps>;
-    renderAppBar?: (props: CLBarProps) => React.ReactElement<CLBarProps>;
+    renderScrollComponent?: (props: ScrollViewProperties) => React.ReactElement<any> | null;
+    renderBottomBar?: (props: CLBarProps) => React.ReactElement<CLBarProps> | null;
+    renderAppBar?: (props: CLBarProps) => React.ReactElement<CLBarProps> | null;
     appBarScrollBehaviours?: CLScrollBehaviour[];
     bottomBarScrollBehaviours?: CLScrollBehaviour[];
     appBarContentRenderer?: (index: number, offset: Animated.AnimatedInterpolation) => React.ReactElement<any> | undefined | null;

--- a/lib/Container.tsx
+++ b/lib/Container.tsx
@@ -30,6 +30,7 @@ export interface CLContainerProps extends ViewProperties {
 
     onProgress?: (offset: number, animatedInterpolation: Animated.AnimatedInterpolation, CLBehaviourModel: CLBehaviourModel) => void;
     onLayout?: (event: LayoutChangeEvent) => void;
+    showSeparator?: boolean;
 }
 
 export interface CLBehaviourModel {
@@ -78,7 +79,8 @@ export class CLContainer extends React.Component<CLContainerProps> {
         const hasAppBar = this.props.appBarScrollBehaviours && this.props.appBarScrollBehaviours.length > 0 && this.props.appBarContentRenderer !== undefined;
         const hasBottomBar = this.props.bottomBarScrollBehaviours && this.props.bottomBarScrollBehaviours.length > 0 && this.props.bottomBarContentRenderer !== undefined;
         const safeAreaInsets = this.props.safeAreaInsets ? this.props.safeAreaInsets : { top: 0, left: 0, bottom: 0, right: 0 };
-
+        const showSeparator = !!this.props.showSeparator
+        
         const paddingTop = hasAppBar ? 0 : safeAreaInsets.top;
         const paddingBottom = hasBottomBar ? 0 : safeAreaInsets.bottom;
 
@@ -118,7 +120,7 @@ export class CLContainer extends React.Component<CLContainerProps> {
                             scrollBehaviourOffset: scrollBehvavioutOffsetInterpolation,
                             scrollBehaviours: this.props.appBarScrollBehaviours,
                             contentRenderer: this.props.appBarContentRenderer,
-                            showSeparator: true
+                            showSeparator: showSeparator
                         })
                     ) : (
                             <CLAppBar
@@ -127,7 +129,7 @@ export class CLContainer extends React.Component<CLContainerProps> {
                                 scrollBehaviourOffset={scrollBehvavioutOffsetInterpolation}
                                 scrollBehaviours={this.props.appBarScrollBehaviours}
                                 contentRenderer={this.props.appBarContentRenderer}
-                                showSeparator={true}
+                                showSeparator={showSeparator}
                             />
                         )
                 ) : (
@@ -141,7 +143,7 @@ export class CLContainer extends React.Component<CLContainerProps> {
                             scrollBehaviourOffset: scrollBehvavioutOffsetInterpolation,
                             scrollBehaviours: this.props.bottomBarScrollBehaviours,
                             contentRenderer: this.props.bottomBarContentRenderer,
-                            showSeparator: true
+                            showSeparator: showSeparator
                         })
                     ) : (
                             <CLBottomBar
@@ -150,7 +152,7 @@ export class CLContainer extends React.Component<CLContainerProps> {
                                 scrollBehaviourOffset={scrollBehvavioutOffsetInterpolation}
                                 scrollBehaviours={this.props.bottomBarScrollBehaviours}
                                 contentRenderer={this.props.bottomBarContentRenderer}
-                                showSeparator={true}
+                                showSeparator={showSeparator}
                             />
                         )
                 ) : (

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "deploy": "sh scripts/deploy.sh",
     "publishRelease": "sh scripts/publishRelease.sh",
     "publishLocal": "sh scripts/publishLocal.sh",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepare": "npm run deploy"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "type": "git",
     "url": "git+ssh://git@github.com:flipkart-incubator/kubric.git"
   },
-  "dependencies": {
-    "react": "16.0.0-beta.5",
-    "react-native": "0.49.5",
-    "react-native-web": "0.6.0"
+  "peerDependencies": {
+    "react": ">= 16.0.0-beta.5",
+    "react-native": ">= 0.49.5",
+    "react-native-web": ">= 0.6.0"
   },
   "devDependencies": {
     "@types/react": "16.0.40",
@@ -29,7 +29,10 @@
     "react-native-typescript-transformer": "1.2.10",
     "rimraf": "2.6.2",
     "tslint": "5.10.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.2",
+    "react": "16.0.0-beta.5",
+    "react-native": "0.49.5",
+    "react-native-web": "0.6.0"
   },
   "keywords": [
     "ballet",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "copyfiles": "^2.1.0",
     "react-native-typescript-transformer": "1.2.10",
     "rimraf": "2.6.2",
-    "tslint": "5.10.0"
+    "tslint": "5.10.0",
+    "typescript": "^4.0.2"
   },
   "keywords": [
     "ballet",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,8 +2,8 @@
 echo 'Removing package-lock.json'
 rm -rf package-lock.json
 
-echo 'Installing npm...'
-npm install
+#echo 'Installing npm...'
+#npm install
 
 echo 'Removing dist...'
 rm -rf dist


### PR DESCRIPTION
Internally we are animating on height, which is not supported in react-native when useNativeDriver:true. 
So in this PR I have removed height animations from library. 

Other Changes:
1. Removed unused variables
2. Removed animation on height
3. Added render props return type as null also
4. Fixed the hardcoded showSeparator as always true
5. Moved react, react-native, react-native-web to peerDependency and add typescript as devDependency
6. remove npm install from deploy script. 
